### PR TITLE
Responsive breakpoints below 600px + responsive webcam video box (#11, #12)

### DIFF
--- a/src/ui/components/CamInput.js
+++ b/src/ui/components/CamInput.js
@@ -71,17 +71,14 @@ class CamInput {
   size() {
     this.width = this.element.offsetWidth;
     this.height = this.width;
+    // These attributes only set a fallback intrinsic size; the actual
+    // rendered box size/aspect ratio is controlled by CSS
+    // (.input__media's aspect-ratio in machine.styl, plus the
+    // `width: 100% !important; height: 100% !important` rules on the
+    // video element itself), which is what responsive sizing (#12) is
+    // implemented in instead of here.
     this.webcamClassifier.video.width = 227;
-		this.webcamClassifier.video.height = 227;
-
-    /*
-    if (this.videoRatio > 1) {
-            this.webcamClassifier.video.width = this.height * this.videoRatio;
-            this.webcamClassifier.video.height = this.height;
-    }else {
-            this.webcamClassifier.video.width = this.width;
-            this.webcamClassifier.video.height = this.width / this.videoRatio;
-    }*/
+    this.webcamClassifier.video.height = 227;
   }
 }
 

--- a/style/components/machine.styl
+++ b/style/components/machine.styl
@@ -550,8 +550,26 @@
 		margin-right: space(1)
 	}
 
+	// Below 900px, hide the decorative connector wires entirely rather
+	// than keep patching their layout. They're purely cosmetic (each
+	// class's colored train button + confidence meter, and the colored
+	// circles in OUTPUT, already show the same class-to-output mapping),
+	// and the mobile version was never actually responsive - it's a
+	// single static SVG (unlike the JS canvas version used above 900px,
+	// which computes exact positions every frame) sharing a flex-wrap row
+	// with real content. That produced three separate real bugs found
+	// via live testing: it visually overlapped the learning card in
+	// portrait, it landed in a disconnected floating position with a
+	// ~326px dead gap at 800-900px (found by sweeping widths in 20px
+	// steps - at that width "learning" and "wires-right" happen to fit
+	// side-by-side on the same flex-wrap row instead of stacking), and
+	// its "tangled wires" artwork - a reasonable flourish across a wide
+	// desktop canvas - just reads as meaningless crossing squiggles once
+	// compressed into a narrow mobile box. None of these are fixable by
+	// adding another breakpoint; the next "sweet spot" width where two
+	// flex items happen to fit together would just move somewhere else.
 	.wires {
-		margin-top: 51px
+		display: none
 	}
 
 	.wires__bulb {
@@ -714,17 +732,12 @@
 		}
 	}
 
-	.wires-svg {
-		display: block
-	}
-
-	.wires--left,
-	.wires--right {
-		height: auto
-		width: 65vw
-		max-width: 400px
-		margin: 0 auto
-	}
+	// .wires-svg display and .wires--left/.wires--right sizing rules were
+	// removed here - moot now that .wires itself is display: none above.
+	// The .wire-base-*/.wire-green etc. color+animation rules below are
+	// left in place even though currently inert (parent hidden): they're
+	// only ever referenced by WiresLeft.highlight() adding an `.animate`
+	// class, which is harmless to leave running against a hidden element.
 
 	.wire-base-green,
 	.wire-base-purple,
@@ -944,38 +957,7 @@
 	}
 }
 
-/*
- * Phone landscape (short viewport height, e.g. 844x390 on an iPhone 12
- * Pro rotated, or 667x375).
- *
- * The decorative connector wires below 900px are sized with
- * `width: 65vw; max-width: 400px` (see the 900px tier above) - tuned
- * for portrait phones, where 65vw of a ~375-600px-wide viewport is a
- * reasonable 244-390px. In landscape, the viewport is wide but short:
- * 65vw of 844px is 548px (capped to the 400px max), which is as wide
- * as or wider than the actual content sections. Since .machine__sections
- * is a wrapping flex row and the wires are flex siblings of the real
- * .section elements (not absolutely positioned), a wire that wide
- * dominates the row and scrambles where the real sections wrap to -
- * confirmed by measuring section positions at 844x390, where the
- * input section collapsed to 69x65px and sections landed in an order
- * that had no visual relationship to the actual layout.
- *
- * Making these connectors correctly reflow for arbitrary landscape
- * aspect ratios would need real (width AND height aware) positioning
- * logic, disproportionate effort for a purely decorative element that
- * was already just an approximate visual flourish below 900px (not
- * precisely connected to real element positions even in portrait -
- * see the WiresLeft/WiresRight canvas renderers, which only ever
- * compute exact pixel connections above 900px). Hiding them here is a
- * deliberate choice over attempting a fragile reflow: they add no
- * functional information (the colors/highlight state are also shown
- * directly on each class's "Confidence" meter and train button), so
- * removing them in this narrow case avoids visual breakage without
- * losing anything a user needs.
- */
-@media screen and (orientation: landscape) and (max-height: 500px) {
-	.wires {
-		display: none
-	}
-}
+// A landscape-only @media (orientation: landscape) and (max-height: 500px)
+// rule used to live here, hiding .wires only in landscape. Superseded:
+// .wires is now display: none for the whole ≤900px tier (see above),
+// which covers landscape too, so this dedicated rule is no longer needed.

--- a/style/components/machine.styl
+++ b/style/components/machine.styl
@@ -71,7 +71,13 @@
 	border-radius: 12px
 	overflow: hidden
 	position: relative
-	height: 270px
+	// Scale height to width instead of a fixed 270px, so the box stays
+	// close to the video's own aspect ratio at any viewport width. A fixed
+	// height combined with a flexible (per-breakpoint) width let this box
+	// turn into a short, wide rectangle on mobile, letterboxing the video
+	// with large white bars (visible via object-fit: contain below).
+	// 300/270 matches this box's original desktop proportions.
+	aspect-ratio: 300 / 270
 	width: 100%
 	margin: 0
 	box-sizing: border-box
@@ -595,7 +601,7 @@
 		}
 
 		.input__media {
-			height: 270px
+			// height comes from the base .input__media aspect-ratio now
 			order: 2
 			margin-bottom: 0
 		}

--- a/style/components/machine.styl
+++ b/style/components/machine.styl
@@ -902,3 +902,37 @@
 		max-width: 100%
 	}
 }
+
+/*
+ * Very small phones (≤ 480px, e.g. iPhone SE at 375px).
+ *
+ * Below this, the 900px tier's 3-across .learning__class layout (each
+ * class squeezed into ~32% width) gets too cramped: "TRAIN GREEN" /
+ * "TRAIN PURPLE" / "TRAIN ORANGE" wrap awkwardly and the examples
+ * thumbnail, confidence meter, and button are packed into ~100px-wide
+ * columns. Switch to one full-width row per class instead, reusing the
+ * same left-thumbnail / right-column layout the desktop (> 900px) tier
+ * already uses via .learning__class-column, just full-width instead of
+ * a fixed 360px section.
+ */
+@media screen and (max-width: 480px) {
+	// The 900px tier's .section__container is flex-wrap: nowrap (fine when
+	// 3 children sum to 32%*3 ~= 96% width), but with .learning__class now
+	// 100% wide each, nowrap would force all 3 into one overflowing row
+	// instead of stacking - so wrap it here too.
+	.section--learning .section__container {
+		flex-wrap: wrap
+	}
+
+	.learning__class {
+		flex: 0 0 100%
+		max-width: 100%
+		flex-direction: row
+		align-items: flex-start
+		margin-bottom: space(1.5)
+	}
+
+	.examples {
+		margin-right: space(1.5)
+	}
+}

--- a/style/components/machine.styl
+++ b/style/components/machine.styl
@@ -622,6 +622,13 @@
 
 	.section--learning {
 		height: auto
+		// Cancel the base rule's `top: -10px` (a cosmetic nudge that only
+		// makes sense on desktop, where the connector wires are
+		// precisely-positioned canvas drawings independent of document
+		// flow). Below 900px, .section--learning is a normal flex-wrap
+		// sibling of .wires-left's decorative SVG, so that -10px pulled it
+		// up into the wire's tail end, making the connector look clipped.
+		top: 0
 
 		.section__container {
 			justify-content: center
@@ -934,5 +941,41 @@
 
 	.examples {
 		margin-right: space(1.5)
+	}
+}
+
+/*
+ * Phone landscape (short viewport height, e.g. 844x390 on an iPhone 12
+ * Pro rotated, or 667x375).
+ *
+ * The decorative connector wires below 900px are sized with
+ * `width: 65vw; max-width: 400px` (see the 900px tier above) - tuned
+ * for portrait phones, where 65vw of a ~375-600px-wide viewport is a
+ * reasonable 244-390px. In landscape, the viewport is wide but short:
+ * 65vw of 844px is 548px (capped to the 400px max), which is as wide
+ * as or wider than the actual content sections. Since .machine__sections
+ * is a wrapping flex row and the wires are flex siblings of the real
+ * .section elements (not absolutely positioned), a wire that wide
+ * dominates the row and scrambles where the real sections wrap to -
+ * confirmed by measuring section positions at 844x390, where the
+ * input section collapsed to 69x65px and sections landed in an order
+ * that had no visual relationship to the actual layout.
+ *
+ * Making these connectors correctly reflow for arbitrary landscape
+ * aspect ratios would need real (width AND height aware) positioning
+ * logic, disproportionate effort for a purely decorative element that
+ * was already just an approximate visual flourish below 900px (not
+ * precisely connected to real element positions even in portrait -
+ * see the WiresLeft/WiresRight canvas renderers, which only ever
+ * compute exact pixel connections above 900px). Hiding them here is a
+ * deliberate choice over attempting a fragile reflow: they add no
+ * functional information (the colors/highlight state are also shown
+ * directly on each class's "Confidence" meter and train button), so
+ * removing them in this narrow case avoids visual breakage without
+ * losing anything a user needs.
+ */
+@media screen and (orientation: landscape) and (max-height: 500px) {
+	.wires {
+		display: none
 	}
 }

--- a/style/components/pwa.styl
+++ b/style/components/pwa.styl
@@ -141,26 +141,24 @@
     padding-top: 20px;
     padding-bottom: 20px;
   }
-  
-  .machine {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-  }
-  
-  .input {
-    flex: 1;
-    margin-right: 20px;
-  }
-  
-  .learning {
-    flex: 1;
-  }
-  
-  .output {
-    width: 100%;
-    margin-top: 20px;
-  }
+
+  /*
+   * This block used to also set .input/.learning/.output to
+   * flex: 1/flex: 1/width: 100% here. Removed: those bare-class
+   * selectors have the same CSS specificity as machine.styl's
+   * .section rules, and since this file is @imported after
+   * machine.styl (see style/main.styl), it silently won every tie -
+   * overriding the actual (tested, breakpoint-based) responsive layout
+   * for .section--input/.section--learning/.section--output on any
+   * landscape view under 900px wide, in ways that were never
+   * integrated with that system. Confirmed via computed-style
+   * inspection: .section--input was resolving to `flex: 1 1 0%` from
+   * this rule instead of the intended tiered .section flex-basis,
+   * which (combined with the connector wires competing for the same
+   * row) produced the reported "sections in random positions, wires
+   * floating in an empty gap" landscape bug. Width-based breakpoints
+   * in machine.styl now apply consistently regardless of orientation.
+   */
 }
 
 /* High DPI screen optimizations */


### PR DESCRIPTION
## Summary

Closes #11 and #12 on one branch (both Mobile phase, tightly related — #12's fix also removes a duplicate fixed-height rule that lived inside the same breakpoint tier #11 adds a sibling for).

### #11 — Breakpoints below 600px
- Checked every `.styl` file for existing media queries: 600px was the narrowest anywhere, confirming INSPECTION.md's finding.
- Verified `machine.styl` (main layout), `wizard.styl`, and `faq.styl` per the issue's ask. The launch screen, tutorial wizard, and FAQ all already degrade cleanly at small widths — no changes needed there.
- Found the real problem via screenshots, not guessing: the three training class cards ("TRAIN GREEN/PURPLE/ORANGE") stay locked to the 900px tier's 3-across `flex: 0 0 32%` layout all the way down to 320px, so on an iPhone SE (375px) each column is squeezed to ~110px and text wraps awkwardly.
- Added a `max-width: 480px` breakpoint that stacks the three classes into full-width rows instead, reusing the same thumbnail-left/details-right composition the desktop tier already uses.
- Along the way, caught (via screenshot, not code review) that this alone caused the three now-100%-wide rows to overflow sideways instead of stacking, because the parent container had an inherited `flex-wrap: nowrap` from the 900px tier. Fixed by overriding it to `wrap` for this breakpoint.

### #12 — Responsive webcam video box
- Investigated the commented-out aspect-ratio block in `CamInput.js` first, per the issue. It only ever set the `<video>` element's `width`/`height` HTML attributes — a later-added `width: 100% !important; height: 100% !important` CSS rule on `.input__media video` already fully overrides those for actual rendered size, so reviving it would not have changed anything visible. Confirmed via `git log --follow` that this hardcoded-227 + disabled block is original code from the very first commit in this repo's history, not something a later change broke.
- The real bug: `.input__media` had a fixed `height: 270px` while its width is flexible (varies per breakpoint), so on mobile the box became a short, wide rectangle and `object-fit: contain` letterboxed the video with large white bars.
- Fixed by replacing the fixed height with `aspect-ratio: 300 / 270` (matching the box's original desktop proportions), so height now scales with width at every breakpoint. Removed the now-redundant duplicate `height: 270px` inside the 900px tier.
- Removed the dead commented block in `CamInput.js`, left a comment pointing at the real (CSS) fix for a future reader.

### Update — wire connectors: hidden below 900px (was: patched)

Live testing kept finding new problems with the decorative connector wires (SVG lines between INPUT→LEARNING→OUTPUT, shown below 900px in place of the desktop's precisely-positioned canvas version) after each patch, and asked for my honest take on whether they belong on mobile at all.

**What was found:**
1. At 414px, the connector reads as a messy tangle of crossing lines, not a legible diagram — confirmed by cropping a screenshot to just that element. The artwork was designed to look like a deliberately tangled bundle of wires across a *wide desktop canvas*; compressed into a ~250px mobile box, it just reads as visual noise.
2. Sweeping every 20px from 400px to 900px (instead of re-testing the same values as before) found a ~326px dead gap with the wire floating disconnected, specifically at 800–900px. Root cause: input/wires-left/learning/wires-right/output are all plain siblings in one flex-wrap row, and at that exact width, `learning` and `wires-right` happen to fit side-by-side on the same row instead of stacking — breaking the intended top-to-bottom flow. **This isn't fixable by adding another breakpoint** — the next width where two items happen to fit together on a row would just move the same failure elsewhere.

**My recommendation, given honestly rather than just patched around**: hide the wires entirely below 900px (the same width where the JS canvas-precise desktop version already turns itself off), rather than keep chasing an approach that's fragile by construction. They're purely decorative — every class's colored train button + confidence meter, and OUTPUT's colored circles, already show the same class-to-output mapping — so nothing functional is lost. Implemented this: removed the now-dead SVG sizing rules it superseded, and the landscape-only hide rule from the previous commit (redundant now, since the ≤900px hide covers landscape too).

## Testing

No visual DevTools access in my environment, so I installed `playwright-core` and drove a real, headless Chrome (WebGL via swiftshader) against `npm run budo`:

- **#12**: screenshots at 320/375/414/480/600/900/1280px — before the fix, 600px showed clear letterboxing; after, the video fills the box edge-to-edge at every width, 1280px (desktop) visually unchanged.
- **#11**: screenshots at the same widths — below 480px, three class cards stack as full-width rows with no wrapped/cramped text; 600px/900px/1280px unchanged.
- **Wire fix (final)**: swept every 20px from 400–900px (not just spot-checking prior values) and confirmed the dead-gap/floating-wire pattern is gone — the one remaining "gap" in a naive top/bottom measurement is normal masonry-style column-height variance (confirmed via screenshot, not a floating element). Cropped a screenshot to the connector region at 414px to confirm the crossing-line visual noise is resolved (wires hidden entirely). Landscape re-verified at 844×390 and 667×375 — clean layout, no disconnection. `document.documentElement.scrollWidth` vs `clientWidth` checked across 11 width/orientation combinations — zero horizontal overflow anywhere.

I did not have access to a real device or Chrome DevTools' actual device toolbar in this environment — everything above is via headless Chrome at exact pixel widths/orientations, which should be a good proxy but isn't identical to your live test. Per your instructions, **not merging this myself** — leaving this for your visual confirmation across a few screen sizes and orientations first.